### PR TITLE
create react-native-navigation sample

### DIFF
--- a/react-native/StorylyDemoTypeScript/App.tsx
+++ b/react-native/StorylyDemoTypeScript/App.tsx
@@ -8,30 +8,33 @@
  * @format
  */
 
+// In index.js of a new project
 import React from 'react';
-import {
-  SafeAreaView,
-  StatusBar,
-  useColorScheme,
-} from 'react-native';
-
-import {
-  Colors,
-} from 'react-native/Libraries/NewAppScreen';
-
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { Navigation } from 'react-native-navigation';
 import { Storyly } from 'storyly-react-native';
 
-const App = () => {
-  const isDarkMode = useColorScheme() === 'dark';
-
-  const backgroundStyle = {
-    backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
-  };
-
+// Home screen declaration
+const HomeScreen = (props) => {
+  console.log("Storyly:HomeScreen:render");
   return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <Storyly
+    <View style={{flex: 1}}>
+      <Button
+        title='Push Settings Screen'
+        color='#710ce3'
+        onPress={() => Navigation.push(props.componentId, {
+          component: {
+            name: 'Settings',
+            options: {
+              topBar: {
+                title: {
+                  text: 'Settings'
+                }
+              }
+            }
+          }
+        })}/>
+        <Storyly
         style={{ height: "100%" }}
         storylyId="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjc2MCwiYXBwX2lkIjo0MDUsImluc19pZCI6NDA0fQ.1AkqOy_lsiownTBNhVOUKc91uc9fDcAxfQZtpm3nj40"
         onLoad={event => { console.log("[Storyly] onLoad"); }}
@@ -42,8 +45,55 @@ const App = () => {
         onStoryClose={() => { console.log("[Storyly] onStoryClose"); }}
         onUserInteracted={event => { console.log("[Storyly] onUserInteracted"); }}
       />
-    </SafeAreaView>
+    </View>
   );
 };
+HomeScreen.options = {
+  topBar: {
+    title: {
+      text: 'Home',
+      color: 'white'
+    },
+    background: {
+      color: '#4d089a'
+    }
+  }
+};
 
-export default App;
+// Settings screen declaration - this is the screen we'll be pushing into the stack
+const SettingsScreen = () => {
+  console.log("levo:SettingsScreen:render");
+  return (
+    <View style={styles.root}>
+      <Text>Settings Screen</Text>
+    </View>
+  );
+}
+
+Navigation.registerComponent('Home', () => HomeScreen);
+Navigation.registerComponent('Settings', () => SettingsScreen);
+
+Navigation.events().registerAppLaunchedListener(async () => {
+  Navigation.setRoot({
+    root: {
+      stack: {
+        children: [
+          {
+            component: {
+              name: 'Home'
+            }
+          }
+        ]
+      }
+    }
+  });
+});
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'whitesmoke'
+  }
+});

--- a/react-native/StorylyDemoTypeScript/App.tsx
+++ b/react-native/StorylyDemoTypeScript/App.tsx
@@ -62,7 +62,7 @@ HomeScreen.options = {
 
 // Settings screen declaration - this is the screen we'll be pushing into the stack
 const SettingsScreen = () => {
-  console.log("levo:SettingsScreen:render");
+  console.log("Storyly:SettingsScreen:render");
   return (
     <View style={styles.root}>
       <Text>Settings Screen</Text>

--- a/react-native/StorylyDemoTypeScript/android/app/src/main/java/com/storylydemotypescript/MainActivity.java
+++ b/react-native/StorylyDemoTypeScript/android/app/src/main/java/com/storylydemotypescript/MainActivity.java
@@ -1,15 +1,8 @@
 package com.storylydemotypescript;
 
-import com.facebook.react.ReactActivity;
+import com.reactnativenavigation.NavigationActivity;
 
-public class MainActivity extends ReactActivity {
+public class MainActivity extends NavigationActivity {
 
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "StorylyDemoTypeScript";
-  }
+  
 }

--- a/react-native/StorylyDemoTypeScript/android/app/src/main/java/com/storylydemotypescript/MainApplication.java
+++ b/react-native/StorylyDemoTypeScript/android/app/src/main/java/com/storylydemotypescript/MainApplication.java
@@ -3,18 +3,19 @@ package com.storylydemotypescript;
 import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
+import com.reactnativenavigation.NavigationApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
+import com.reactnativenavigation.react.NavigationReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
+public class MainApplication extends NavigationApplication {
 
   private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHost(this) {
+      new NavigationReactNativeHost(this) {
         @Override
         public boolean getUseDeveloperSupport() {
           return BuildConfig.DEBUG;
@@ -43,7 +44,7 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
-    SoLoader.init(this, /* native exopackage */ false);
+    
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 

--- a/react-native/StorylyDemoTypeScript/android/build.gradle
+++ b/react-native/StorylyDemoTypeScript/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext {
+        RNNKotlinVersion = "1.5.31"
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 31

--- a/react-native/StorylyDemoTypeScript/ios/Podfile.lock
+++ b/react-native/StorylyDemoTypeScript/ios/Podfile.lock
@@ -72,6 +72,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
+  - HMSegmentedControl (1.5.6)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
   - RCT-Folly (2021.06.28.00-v2):
@@ -337,6 +338,21 @@ PODS:
     - React-jsi (= 0.67.4)
     - React-logger (= 0.67.4)
     - React-perflogger (= 0.67.4)
+  - ReactNativeNavigation (7.28.0):
+    - HMSegmentedControl
+    - React-Core
+    - React-RCTImage
+    - React-RCTText
+    - ReactNativeNavigation/Core (= 7.28.0)
+  - ReactNativeNavigation/Core (7.28.0):
+    - HMSegmentedControl
+    - React-Core
+    - React-RCTImage
+    - React-RCTText
+  - Storyly (1.23.2)
+  - storyly-react-native (1.23.2):
+    - React
+    - Storyly (~> 1.23.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -395,6 +411,8 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - ReactNativeNavigation (from `../node_modules/react-native-navigation`)
+  - storyly-react-native (from `../node_modules/storyly-react-native`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -410,8 +428,10 @@ SPEC REPOS:
     - Flipper-RSocket
     - FlipperKit
     - fmt
+    - HMSegmentedControl
     - libevent
     - OpenSSL-Universal
+    - Storyly
     - YogaKit
 
 EXTERNAL SOURCES:
@@ -473,6 +493,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  ReactNativeNavigation:
+    :path: "../node_modules/react-native-navigation"
+  storyly-react-native:
+    :path: "../node_modules/storyly-react-native"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -493,6 +517,7 @@ SPEC CHECKSUMS:
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
@@ -519,9 +544,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: 3b52a7dced19cdb025b4f88ab26ceb2d85f30ba2
   React-runtimeexecutor: a9d3c82ddf7ffdad9fbe6a81c6d6f8c06385464d
   ReactCommon: 07d0c460b9ba9af3eaf1b8f5abe7daaad28c9c4e
+  ReactNativeNavigation: d82a136212f3a581e256b181e5703aa2f79ecba4
+  Storyly: f4218f5e4ff820e58e0bb7f78c86a9401265e266
+  storyly-react-native: 84ec6752fd86ce69a1aedd2800a05e151dfdc90c
   Yoga: d6b6a80659aa3e91aaba01d0012e7edcbedcbecd
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 51b74f8d0652e8e5c78ead7d2e2009bb16ae901f
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/react-native/StorylyDemoTypeScript/ios/StorylyDemoTypeScript/AppDelegate.m
+++ b/react-native/StorylyDemoTypeScript/ios/StorylyDemoTypeScript/AppDelegate.m
@@ -1,8 +1,8 @@
 #import "AppDelegate.h"
+#import <ReactNativeNavigation/ReactNativeNavigation.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
-#import <React/RCTRootView.h>
 
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
@@ -32,22 +32,14 @@ static void InitializeFlipper(UIApplication *application) {
 #endif
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                                   moduleName:@"StorylyDemoTypeScript"
-                                            initialProperties:nil];
+[ReactNativeNavigation bootstrapWithBridge:bridge];
+  
 
-  if (@available(iOS 13.0, *)) {
-      rootView.backgroundColor = [UIColor systemBackgroundColor];
-  } else {
-      rootView.backgroundColor = [UIColor whiteColor];
-  }
-
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [UIViewController new];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
-  [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge {
+  return [ReactNativeNavigation extraModulesForBridge:bridge];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/react-native/StorylyDemoTypeScript/package.json
+++ b/react-native/StorylyDemoTypeScript/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "17.0.2",
     "react-native": "0.67.4",
-    "storyly-react-native": "^1.20.0"
+    "react-native-navigation": "^7.28.0",
+    "storyly-react-native": "^1.23.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/react-native/StorylyDemoTypeScript/yarn.lock
+++ b/react-native/StorylyDemoTypeScript/yarn.lock
@@ -3394,6 +3394,13 @@ hermes-profile-transformer@^0.0.6:
   dependencies:
     source-map "^0.7.3"
 
+hoist-non-react-statics@3.x.x:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -4480,7 +4487,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.7.0:
+lodash@4.17.x, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5451,7 +5458,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.x.x, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5501,10 +5508,15 @@ react-devtools-core@4.19.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-lifecycles-compat@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-2.0.0.tgz#71d9c4cde47114c4102454f76da055c2bc48c948"
+  integrity sha512-txfpPCQYiazVdcbMRhatqWKcAxJweUu2wDXvts5/7Wyp6+Y9cHojqXHsLPEckzutfHlxZhG8Oiundbmp8Fd6eQ==
 
 react-native-codegen@^0.0.8:
   version "0.0.8"
@@ -5514,6 +5526,17 @@ react-native-codegen@^0.0.8:
     flow-parser "^0.121.0"
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
+
+react-native-navigation@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-7.28.0.tgz#536942995f24b78a33b5b6e5e6e42f269cf72167"
+  integrity sha512-rHLuJLzheUY5JYP0UuuNNz5f3yh3kmmwj+sZIQyDh+WksJqtREgmTqxuSs2X8SnE5QoEcm5WsNuw3P9HuyWbJw==
+  dependencies:
+    hoist-non-react-statics "3.x.x"
+    lodash "4.17.x"
+    prop-types "15.x.x"
+    react-lifecycles-compat "2.0.0"
+    tslib "1.9.3"
 
 react-native@0.67.4:
   version "0.67.4"
@@ -6202,10 +6225,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-storyly-react-native@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/storyly-react-native/-/storyly-react-native-1.20.0.tgz#d69d007517d1c86a5b063627ad10cc554365f8f1"
-  integrity sha512-1rOXsqker8riGafkZB1lYlsv/KvVvGhDFKqkunFfJ4rtW7ttQ8d5+ZdAB3OCsyAloRocJUANBnrAX77B7/ohkw==
+storyly-react-native@^1.23.2:
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/storyly-react-native/-/storyly-react-native-1.23.2.tgz#21b21dd087f94d0cec8f87d73f6f39f5118afc63"
+  integrity sha512-qRCuczZAar7AhMzgZ2hhvgdOT/hZSpKrlZuwk/vbKbUINKjbGBMhfEfgbQUp2LEiIdZ1NdnFALUqeeVVVhyOTw==
 
 stream-buffers@2.2.x:
   version "2.2.0"
@@ -6465,6 +6488,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+tslib@1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
we've reproduced the 'freeze' issue with this sample; 
- open app in home screen that contains StorylyView 
- navigate another screen
- wait 10-15mins
- press back button to return home screen with StorylyView 
- observe 'freeze' in app

We add a log inside [RnStoryly:render](https://github.com/Netvent/storyly-mobile/blob/master/react-native/storyly-react-native/RNStoryly.js#L89) method to observe lifecycle; returning to the page does not trigger render of components.

We add logs inside [Android StorylyView wrapper init](https://github.com/Netvent/storyly-mobile/blob/master/react-native/storyly-react-native/android/src/main/java/com/appsamurai/storyly/reactnative/STStorylyView.kt#L18), [StorylyView doFrame](https://github.com/Netvent/storyly-mobile/blob/master/react-native/storyly-react-native/android/src/main/java/com/appsamurai/storyly/reactnative/STStorylyView.kt#L92), [StorylyView's onAttachedToWindow](https://github.com/Netvent/storyly-mobile/blob/master/react-native/storyly-react-native/android/src/main/java/com/appsamurai/storyly/reactnative/STStorylyView.kt#L15) and [StorylyView's onMeasure](https://github.com/Netvent/storyly-mobile/blob/master/react-native/storyly-react-native/android/src/main/java/com/appsamurai/storyly/reactnative/STStorylyView.kt#L15) methods to observe.