### PR TITLE
add sourceCompatibility and targetCompatibility 1.8 as compileOptions for react-native's android project

### DIFF
--- a/react-native/storyly-react-native/android/build.gradle
+++ b/react-native/storyly-react-native/android/build.gradle
@@ -45,11 +45,9 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 
-    android {
-        compileOptions {
-            sourceCompatibility 1.8
-            targetCompatibility 1.8
-        }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
     
     defaultConfig {

--- a/react-native/storyly-react-native/android/build.gradle
+++ b/react-native/storyly-react-native/android/build.gradle
@@ -44,6 +44,14 @@ buildscript {
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+
+    android {
+        compileOptions {
+            sourceCompatibility 1.8
+            targetCompatibility 1.8
+        }
+    }
+    
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)


### PR DESCRIPTION
Related issue
https://github.com/Netvent/storyly-mobile/issues/198