### PR TITLE
Fix the issue when the FlutterViewController is not the rootViewController #26

### DIFF
--- a/flutter/storyly_flutter/ios/Classes/FlutterStorylyViewWrapper.swift
+++ b/flutter/storyly_flutter/ios/Classes/FlutterStorylyViewWrapper.swift
@@ -82,6 +82,9 @@ internal class FlutterStorylyViewWrapper: UIView, StorylyDelegate {
         }
         self.storylyView.delegate = self
         self.storylyView.rootViewController = UIApplication.shared.keyWindow?.rootViewController
+        while self.storylyView.rootViewController?.presentedViewController != nil {
+            self.storylyView.rootViewController = viewController?.presentedViewController
+        }
         self.updateTheme(storylyView: storylyView, args: self.args)
         self.addSubview(storylyView)
         self.storylyView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true

--- a/flutter/storyly_flutter/ios/Classes/FlutterStorylyViewWrapper.swift
+++ b/flutter/storyly_flutter/ios/Classes/FlutterStorylyViewWrapper.swift
@@ -83,7 +83,7 @@ internal class FlutterStorylyViewWrapper: UIView, StorylyDelegate {
         self.storylyView.delegate = self
         self.storylyView.rootViewController = UIApplication.shared.keyWindow?.rootViewController
         while self.storylyView.rootViewController?.presentedViewController != nil {
-            self.storylyView.rootViewController = viewController?.presentedViewController
+            self.storylyView.rootViewController = self.storylyView.rootViewController?.presentedViewController
         }
         self.updateTheme(storylyView: storylyView, args: self.args)
         self.addSubview(storylyView)


### PR DESCRIPTION
Recently I was working on an animated splash screen for our flutter app, and for this purpose, we have to create a launchScreenViewController and make it the rootViewController and run the animation on it, when the animation gets completed we are presenting the flutterViewController in the iOS project.

In this scenario, Storyly native iOS stop working because of the following code

`self.storylyView.rootViewController = UIApplication.shared.keyWindow?.rootViewController`
 assuming that FlutterViewController is always the rootViewController.

I tried to fix that on my fork by using the presentedViewController instead and it was working fine.

This PR is to fix this issue.

Let me know in case you have any questions.