### PR TITLE
fix(flutter-core): fix rootViewController is not presented with extension method

### DIFF
--- a/flutter/storyly_flutter/ios/Classes/FlutterStorylyViewWrapper.swift
+++ b/flutter/storyly_flutter/ios/Classes/FlutterStorylyViewWrapper.swift
@@ -81,7 +81,7 @@ internal class FlutterStorylyViewWrapper: UIView, StorylyDelegate {
             self.storylyView.storylyShareUrl = shareUrl
         }
         self.storylyView.delegate = self
-        self.storylyView.rootViewController = UIApplication.shared.keyWindow?.rootViewController
+        self.storylyView.rootViewController = UIApplication.shared.keyWindow?.rootViewController?.getPresentedViewController()
         self.updateTheme(storylyView: storylyView, args: self.args)
         self.addSubview(storylyView)
         self.storylyView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
@@ -338,6 +338,15 @@ extension FlutterStorylyViewWrapper {
                         "id": storyComponent.id]
 
         }
+    }
+}
+
+extension UIViewController {
+    internal func getPresentedViewController() -> UIViewController? {
+        guard let vc = self.presentedViewController else {
+            return self
+        }
+        return vc.getPresentedViewController()
     }
 }
 


### PR DESCRIPTION
Fixed access to `presentedViewController` implementation referencing https://github.com/Netvent/storyly-mobile/pull/229